### PR TITLE
Pr/1.19/workflows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,25 +6,44 @@
 name: build
 on:
   push:
+    tags-ignore:
+      - '**'
+    branches:
+      - '**'
+    paths-ignore:
+      - '.github/**'
+      - '!.github/workflows/**'
+      - '**.md'
+  workflow_dispatch:
 
 jobs:
   build:
-    if: "contains(toJSON(github.event.commits.*.message), '[release]')"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2
-      - name: setup jdk 17
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v3
         with:
+          fetch-depth: 1
+      - name: validate gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: cache gradle
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: setup jdk 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
           java-version: 17
-      - name: make gradle wrapper executable
-        if: ${{ runner.os != 'Windows' }}
-        run: chmod +x ./gradlew
       - name: build
-        run: ./gradlew build
+        run: ./gradlew build --no-daemon
       - name: capture build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Artifacts
           path: build/libs/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Build and publish with Gradle
+        run: ./gradlew modrinth publish
+        env:
+          BUILD_RELEASE: ${{github.event.prelease == false}}
+          MODRINTH_TOKEN: ${{secrets.MODRINTH}}
+          CHANGELOG: ${{ github.event.release.body }}
+      - name: Upload build artifacts
+        uses: AButler/upload-release-assets@v2.0
+        with:
+          files: 'build/libs/*;!build/libs/*-sources.jar;!build/libs/*-dev.jar'
+          repo-token: ${{secrets.GITHUB_TOKEN}}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
+import java.nio.charset.StandardCharsets
+
 plugins {
 	id 'maven-publish'
 	alias(libs.plugins.quilt.loom)
+	alias(libs.plugins.minotaur)
 }
 
 archivesBaseName = project.archives_base_name
@@ -80,5 +83,24 @@ publishing {
 		// Notice: This block does NOT have the same function as the block in the top level.
 		// The repositories here will be used for publishing your artifact, not for
 		// retrieving dependencies.
+	}
+}
+
+modrinth {
+	token = System.getenv("MODRINTH_TOKEN")
+	projectId = "chocolate-bar"
+	uploadFile = remapJar
+	gameVersions = [libs.versions.minecraft.get()]
+	versionNumber = "v${project.version}"
+	versionName = "Chocolate Bar v${project.version}"
+	loaders = ["quilt"]
+	def ref = System.getenv("GITHUB_REF")
+	changelog = System.getenv("CHANGELOG") ?:
+			(ref != null && ref.startsWith("refs/tags/")) ?
+					"You may view the changelog at https://github.com/woodiertexas/chocolate-bar-2/releases/tag/${URLEncoder.encode(ref.substring(10), StandardCharsets.UTF_8)}" :
+					"No changelog is available. Perhaps poke at https://github.com/woodiertexas/chocolate-bar-2 for a changelog?"
+
+	dependencies {
+		required.project "qsl"
 	}
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,3 +20,4 @@ quilted_fabric_api = ["quilted_fabric_api", "quilted_fabric_api_deprecated"]
 
 [plugins]
 quilt_loom = { id = "org.quiltmc.loom", version = "0.12.+" }
+minotaur = { id = "com.modrinth.minotaur", version = "2.+" }


### PR DESCRIPTION
Similar to woodiertexas/architecture-extensions#10, as requested.

You will need to supply a Modrinth token in the action secret `MODRINTH` to allow for automatic uploading to Modrinth on publish.

Note: Care was taken to follow the preexisting versioning scheme on Modrinth this time.